### PR TITLE
remove abs.yaml

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-upload_channels:
-  - boldorider4-test-channel
-channels:
-  - boldorider4-test-channel


### PR DESCRIPTION
This is a fix for PR [10](https://github.com/AnacondaRecipes/xlsxwriter-feedstock/pull/10) where I forgot to remove abs.yaml.